### PR TITLE
Improve Object Proxy

### DIFF
--- a/addon/-private/object.js
+++ b/addon/-private/object.js
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { notifyPropertyChange } from "@ember/object";
 import { createTagsCache } from "./tags-cache";
 
@@ -25,6 +26,7 @@ function createProxy(obj = {}) {
 
       if (currentValue !== value) propsTags.dirty(p);
 
+      // We need to notify this way to make {{each-in}} update
       notifyPropertyChange(receiver, "_SOME_PROP_");
 
       return result;
@@ -44,9 +46,13 @@ function createProxy(obj = {}) {
       const result = Reflect.defineProperty(target, p, attributes);
       const value = Reflect.get(target, p);
 
+
       keysTags.dirty(OBJECT_KEYS);
       keysTags.dirty(p);
       if (value !== undefined) propsTags.dirty(p);
+
+      // We need to notify this way to make {{each-in}} update
+      notifyPropertyChange(target, "_SOME_PROP_");
 
       return result;
     },
@@ -55,9 +61,13 @@ function createProxy(obj = {}) {
       const currentValue = Reflect.get(target, p);
       const result = Reflect.deleteProperty(target, p);
 
+
       keysTags.dirty(OBJECT_KEYS);
       keysTags.dirty(p);
       if (currentValue !== undefined) propsTags.dirty(p);
+
+      // We need to notify this way to make {{each-in}} update
+      notifyPropertyChange(target, "_SOME_PROP_");
 
       return result;
     },

--- a/addon/-private/tags-cache.ts
+++ b/addon/-private/tags-cache.ts
@@ -1,0 +1,29 @@
+import {
+  dirtyTag,
+  consumeTag,
+  createTag,
+} from "tracked-maps-and-sets/-private/util";
+
+export function createTagsCache() {
+  const cache = new Map();
+
+  return Object.freeze({
+    dirty(key: PropertyKey): void {
+      const tag = cache.get(key);
+      if (tag) dirtyTag(tag);
+    },
+
+    track(key: PropertyKey): void {
+      let tag = cache.get(key);
+
+      if (tag) {
+        consumeTag(tag);
+        return;
+      }
+
+      tag = createTag();
+      cache.set(key, tag);
+      consumeTag(tag);
+    },
+  });
+}


### PR DESCRIPTION
Hi :)

while I was working on [VZN | Reactivity](https://github.com/vznjs/reactivity) I noticed several bugs related to keys tracking, so Im sharing the outcome of long investigations.

Once this will land in VZN I will also add additional tests (unless someone wants to help with that)

What has been fixed:
- `deleteProperty` and `defineProperty` is notifying `ownKeys` change, individual desc's key accessed by `has` and the `property` if tracked
- `has` is now tracking a single object desc's key instead the whole collection
- `set` is notifying the property only if really changed, notifying the desc's key as well the collection if new desc's key has been set