### PR TITLE
Add type tests and fix a types bug they exposed

### DIFF
--- a/addon/-private/object.d.ts
+++ b/addon/-private/object.d.ts
@@ -1,7 +1,7 @@
 declare interface TrackedObject {
   fromEntries<T = unknown>(
     entries: Iterable<readonly [PropertyKey, T]>
-  ): { PropertyKey: T };
+  ): { [k: string]: T };
 
   new <T extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>>(
     obj?: T

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ember": "^10.4.1",
     "eslint-plugin-node": "^11.1.0",
+    "expect-type": "^0.13.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",

--- a/tests/unit/array-test.ts
+++ b/tests/unit/array-test.ts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { TrackedArray } from 'tracked-built-ins';
+import { expectTypeOf } from 'expect-type';
 
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -43,6 +44,10 @@ const ARRAY_SETTER_METHODS = [
   'splice',
   'unshift',
 ];
+
+// We can use a `TrackedArray<T>` anywhere we can use an `Array<T>` (but not
+// vice versa).
+expectTypeOf<TrackedArray<unknown>>().toMatchTypeOf<Array<unknown>>();
 
 module('TrackedArray', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/unit/decorator-test.ts
+++ b/tests/unit/decorator-test.ts
@@ -10,11 +10,14 @@ import {
 
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import { expectTypeOf } from 'expect-type';
 
 module('decorator', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it works as a decorator', (assert) => {
+    expectTypeOf(tracked).toMatchTypeOf<PropertyDecorator>();
+
     class Foo {
       @tracked prop = 123;
     }
@@ -29,32 +32,46 @@ module('decorator', function (hooks) {
   });
 
   test('it works to wrap built-ins by instance', (assert) => {
-    let obj = tracked({});
-    let arr = tracked([]);
-    let map = tracked(new Map());
-    let set = tracked(new Set());
-    let weakMap = tracked(new WeakMap());
-    let weakSet = tracked(new WeakSet());
+    let obj = tracked({ neat: true });
+    let arr = tracked([1, 2, 3]);
+    let map = tracked(new Map<string, number>());
+    let set = tracked(new Set<number>());
+    let weakMap = tracked(new WeakMap<object, string>());
+    let weakSet = tracked(new WeakSet<object>());
 
     assert.ok(obj instanceof TrackedObject, 'obj instanceof TrackedObject');
+    expectTypeOf(obj).toEqualTypeOf<{ neat: boolean }>();
     assert.ok(arr instanceof TrackedArray, 'arr instanceof TrackedArray');
+    expectTypeOf(arr).toEqualTypeOf<TrackedArray<number>>();
     assert.ok(map instanceof TrackedMap, 'map instanceof TrackedMap');
+    expectTypeOf(map).toEqualTypeOf<TrackedMap<string, number>>();
     assert.ok(set instanceof TrackedSet, 'set instanceof TrackedSet');
+    expectTypeOf(set).toEqualTypeOf<TrackedSet<number>>();
     assert.ok(
       weakMap instanceof TrackedWeakMap,
       'weakMap instanceof TrackedWeakMap'
     );
+    expectTypeOf(weakMap).toEqualTypeOf<TrackedWeakMap<object, string>>();
     assert.ok(
       weakSet instanceof TrackedWeakSet,
       'weakSet instanceof TrackedWeakSet'
     );
+    expectTypeOf(weakSet).toEqualTypeOf<TrackedWeakSet<object>>();
 
     assert.ok(obj instanceof Object, 'obj instanceof Object');
+    // The whole point here is that Object *is* the thing we are matching, ESLint!
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    expectTypeOf(obj).toMatchTypeOf<Object>();
     assert.ok(arr instanceof Array, 'arr instanceof Array');
+    expectTypeOf(arr).toMatchTypeOf<Array<number>>();
     assert.ok(map instanceof Map, 'map instanceof Map');
+    expectTypeOf(map).toMatchTypeOf<Map<string, number>>();
     assert.ok(set instanceof Set, 'set instanceof Set');
+    expectTypeOf(set).toMatchTypeOf<Set<number>>();
     assert.ok(weakMap instanceof WeakMap, 'weakMap instanceof WeakMap');
+    expectTypeOf(weakMap).toMatchTypeOf<WeakMap<object, string>>();
     assert.ok(weakSet instanceof WeakSet, 'weakSet instanceof WeakSet');
+    expectTypeOf(weakSet).toMatchTypeOf<WeakSet<object>>();
   });
 
   test('it works to wrap built-ins by constructor', (assert) => {
@@ -66,11 +83,17 @@ module('decorator', function (hooks) {
     let weakSet = tracked(WeakSet);
 
     assert.ok(obj instanceof TrackedObject);
+    expectTypeOf(obj).toEqualTypeOf<ObjectConstructor>();
     assert.ok(arr instanceof TrackedArray);
+    expectTypeOf(arr).toEqualTypeOf<TrackedArray>();
     assert.ok(map instanceof TrackedMap);
+    expectTypeOf(map).toEqualTypeOf<TrackedMap>();
     assert.ok(set instanceof TrackedSet);
+    expectTypeOf(set).toEqualTypeOf<TrackedSet>();
     assert.ok(weakMap instanceof TrackedWeakMap);
+    expectTypeOf(weakMap).toEqualTypeOf<TrackedWeakMap>();
     assert.ok(weakSet instanceof TrackedWeakSet);
+    expectTypeOf(weakSet).toEqualTypeOf<TrackedWeakSet>();
   });
 
   test('objects, arrays, maps, and sets wrap and keep their values', (assert) => {
@@ -80,8 +103,12 @@ module('decorator', function (hooks) {
     let set = tracked(new Set([3]));
 
     assert.equal(obj.foo, 123, 'objects work');
+    expectTypeOf(obj).toEqualTypeOf<{ foo: number }>();
     assert.equal(arr[0], 456, 'arrays work');
+    expectTypeOf(arr).toEqualTypeOf<TrackedArray<number>>();
     assert.equal(map.get(1), 2, 'maps work');
+    expectTypeOf(map).toEqualTypeOf<TrackedMap<number, number>>();
     assert.ok(set.has(3), 'sets work');
+    expectTypeOf(set).toEqualTypeOf<TrackedSet<number>>();
   });
 });

--- a/tests/unit/object-test.ts
+++ b/tests/unit/object-test.ts
@@ -3,11 +3,16 @@ import hbs from 'htmlbars-inline-precompile';
 import { TrackedObject } from 'tracked-built-ins';
 import { render, settled } from '@ember/test-helpers';
 import type { TestContext } from '@ember/test-helpers';
+import { expectTypeOf } from 'expect-type';
 
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import { reactivityTest } from '../helpers/reactivity';
 import { eachInReactivityTest } from '../helpers/collection-reactivity';
+
+// The whole point here is that Object *is* the thing we are matching, ESLint!
+// eslint-disable-next-line @typescript-eslint/ban-types
+expectTypeOf<TrackedObject>().toMatchTypeOf<Object>();
 
 module('TrackedObject', function (hooks) {
   setupRenderingTest(hooks);
@@ -17,6 +22,7 @@ module('TrackedObject', function (hooks) {
     let obj = new TrackedObject(original);
 
     assert.ok(obj instanceof TrackedObject);
+    expectTypeOf(obj).toEqualTypeOf<{ foo: number }>();
     assert.deepEqual(Object.keys(obj), ['foo']);
     assert.equal(obj.foo, 123);
 
@@ -28,10 +34,12 @@ module('TrackedObject', function (hooks) {
   test('preserves getters', (assert) => {
     let obj = new TrackedObject({
       foo: 123,
-      get bar() {
+      get bar(): number {
         return this.foo;
       },
     });
+
+    expectTypeOf(obj).toEqualTypeOf<{ foo: number; readonly bar: number }>();
 
     obj.foo = 456;
     assert.equal(obj.foo, 456, 'object updated correctly');
@@ -39,7 +47,13 @@ module('TrackedObject', function (hooks) {
   });
 
   test('fromEntries', (assert) => {
-    let obj = TrackedObject.fromEntries(Object.entries({ foo: 123 }));
+    const entries = Object.entries({ foo: 123 });
+    let obj = TrackedObject.fromEntries(entries);
+    // We will lose the specific key, becuase `Object.entries` does not preserve
+    // it, but the type produced by `TrackedObject.fromEntries` should match the
+    // type produced by `Object.fromEntries`.
+    let underlying = Object.fromEntries(entries);
+    expectTypeOf(obj).toEqualTypeOf(underlying);
 
     assert.ok(obj instanceof TrackedObject);
     assert.deepEqual(Object.keys(obj), ['foo']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6169,6 +6169,11 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
+expect-type@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.13.0.tgz#916646a7a73f3ee77039a634ee9035efe1876eb2"
+  integrity sha512-CclevazQfrqo8EvbLPmP7osnb1SZXkw47XPPvUUpeMz4HuGzDltE7CaIt3RLyT9UQrwVK/LDn+KVcC0hcgjgDg==
+
 express@^4.10.7, express@^4.17.2:
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"


### PR DESCRIPTION
- `TrackedObject.fromEntries` produced the wrong types as its output; it should always exactly match the underlying type from `Object`.
- Introduce type tests throughout.