### PR TITLE
Ignore generated types in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# generated types
+index.d.ts
+/-private/*.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,0 @@
-export { default as tracked } from './-private/decorator';
-export { default as TrackedArray } from './-private/array';
-export { default as TrackedObject } from './-private/object';
-export { TrackedMap, TrackedWeakMap, TrackedSet, TrackedWeakSet, } from 'tracked-maps-and-sets';


### PR DESCRIPTION
Glorious will be the day when we can just use `exports` maps and get rid of all these shenanigans. 🔜 