### PR TITLE
Update htmlbars imports

### DIFF
--- a/test-app/tests/unit/object-test.ts
+++ b/test-app/tests/unit/object-test.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { TrackedObject } from 'tracked-built-ins';
 import { render, settled } from '@ember/test-helpers';
 import type { TestContext } from '@ember/test-helpers';

--- a/test-app/types/global.d.ts
+++ b/test-app/types/global.d.ts
@@ -1,6 +1,6 @@
 // Types for compiled templates
 declare module 'tracked-built-ins/templates/*' {
-  import { TemplateFactory } from 'htmlbars-inline-precompile';
+  import { TemplateFactory } from 'ember-cli-htmlbars';
   const tmpl: TemplateFactory;
   export default tmpl;
 }


### PR DESCRIPTION
Usage of htmlbars-inline-precompile has been deprecated in favor of ember-cli-htmlbars.