### PR TITLE
Remove unnecessary @babel/plugin-proposal-class-properties

### DIFF
--- a/addon/babel.config.json
+++ b/addon/babel.config.json
@@ -1,7 +1,6 @@
 {
   "presets": [["@babel/preset-typescript"]],
   "plugins": [
-    "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-private-methods",
     ["@babel/plugin-proposal-decorators", { "legacy": true }]
   ]

--- a/addon/package.json
+++ b/addon/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.19.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.20.0",
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,6 @@ importers:
   addon:
     specifiers:
       '@babel/core': ^7.19.6
-      '@babel/plugin-proposal-class-properties': ^7.18.6
       '@babel/plugin-proposal-decorators': ^7.20.0
       '@babel/plugin-proposal-private-methods': ^7.18.6
       '@babel/preset-typescript': ^7.18.6
@@ -47,7 +46,6 @@ importers:
       ember-tracked-storage-polyfill: 1.0.0
     devDependencies:
       '@babel/core': 7.19.6
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.19.6
       '@babel/plugin-proposal-decorators': 7.20.0_@babel+core@7.19.6
       '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.19.6
       '@babel/preset-typescript': 7.18.6_@babel+core@7.19.6


### PR DESCRIPTION
Only perform strictly necessary transforms when building a v2 addon.