### PR TITLE
Fix incorrect mutation-after-consumption assertions for Array `push` and `unshift`

### DIFF
--- a/test-app/tests/unit/array-test.ts
+++ b/test-app/tests/unit/array-test.ts
@@ -387,6 +387,48 @@ module('TrackedArray', function (hooks) {
       }
     );
 
+    reactivityTest(
+      'Can push into a newly created TrackedArray during construction',
+      class extends Component {
+        arr = new TrackedArray<string>();
+
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        constructor(owner: unknown, args: {}) {
+          super(owner, args);
+          this.arr.push('hello');
+        }
+
+        get value() {
+          return this.arr[0];
+        }
+
+        update() {
+          this.arr[0] = 'goodbye';
+        }
+      }
+    );
+
+    reactivityTest(
+      'Can unshift into a newly created TrackedArray during construction',
+      class extends Component {
+        arr = new TrackedArray<string>();
+
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        constructor(owner: unknown, args: {}) {
+          super(owner, args);
+          this.arr.unshift('hello');
+        }
+
+        get value() {
+          return this.arr[0];
+        }
+
+        update() {
+          this.arr[0] = 'goodbye';
+        }
+      }
+    );
+
     eachReactivityTest(
       '{{each}} works with new items',
       class extends Component {


### PR DESCRIPTION
For these methods, `Array` itself immediately gets the `.length` to return after invoking them. Thus, if we are reading `.length`, it may be a normal user-triggered read, or it may be a read triggered by Array itself. In the latter case, it is because we have just done `.push()` or `.unshift()`; in that case it is safe *not* to treat reading `.length` as a *read* operation, since calling `.push()` or `.unshift()` cannot otherwise be part of a "read" operation safely, and if done during an *existing* read (e.g. if the user has already checked `.length` *prior* to this), that will still trigger the assertion.

This PR:

- Introduces a simple failing test. Simply doing a `.push()` or `.unshift()` call after creating the Array during construction of a component is enough to trigger the issue.

- Introduces a flag, which the proxy's `get()` sets to `true` when calling `.push()` or `.unshift()`, and then clear it during the immediately-following `.length` check.

Fixes #29.