### PR TITLE
Use the latest stable version of TypeScript

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '14.x'
   PNPM_VERSION: '7'
 
 jobs:
@@ -26,7 +25,7 @@ jobs:
           version: '${{ env.PNPM_VERSION }}'
       - uses: actions/setup-node@v3
         with:
-          node-version: '${{ env.NODE_VERSION }}'
+          node-version-file: 'package.json' # uses Volta!
           cache: 'pnpm'
 
       - name: Install Dependencies
@@ -58,7 +57,7 @@ jobs:
           version: '${{ env.PNPM_VERSION }}'
       - uses: actions/setup-node@v3
         with:
-          node-version: '${{ env.NODE_VERSION }}'
+          node-version-file: 'package.json' # uses Volta!
           cache: 'pnpm'
 
       - name: Install Dependencies
@@ -85,7 +84,7 @@ jobs:
           version: '${{ env.PNPM_VERSION }}'
       - uses: actions/setup-node@v3
         with:
-          node-version: '${{ env.NODE_VERSION }}'
+          node-version-file: 'package.json' # uses Volta!
           cache: 'pnpm'
 
       - name: Install Dependencies (without lockfile)
@@ -122,7 +121,7 @@ jobs:
           version: '${{ env.PNPM_VERSION }}'
       - uses: actions/setup-node@v3
         with:
-          node-version: '${{ env.NODE_VERSION }}'
+          node-version-file: 'package.json' # uses Volta!
           cache: 'pnpm'
 
       - name: Install Dependencies
@@ -159,7 +158,7 @@ jobs:
           version: '${{ env.PNPM_VERSION }}'
       - uses: actions/setup-node@v3
         with:
-          node-version: '${{ env.NODE_VERSION }}'
+          node-version-file: 'package.json' # uses Volta!
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/addon/package.json
+++ b/addon/package.json
@@ -67,12 +67,9 @@
     "rollup": "^2.74.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-delete": "^2.0.0",
-    "rollup-plugin-ts": "^3.0.2",
+    "rollup-plugin-ts": "^3.2.0",
     "tslib": "^2.4.0",
-    "typescript": "^4.8.4"
-  },
-  "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "typescript": "4.9.4"
   },
   "volta": {
     "extends": "../package.json"

--- a/package.json
+++ b/package.json
@@ -7,17 +7,18 @@
   "license": "MIT",
   "author": "Chris Hewell Garrett",
   "scripts": {
-    "prepare": "cd addon && pnpm run build",
+    "prepublishOnly": "cd addon && pnpm run build",
     "release": "release-it",
     "test": "cd test-app && pnpm run test:ember"
   },
   "devDependencies": {
     "@release-it-plugins/lerna-changelog": "^5.0.0",
     "@release-it-plugins/workspaces": "^3.2.0",
-    "release-it": "^15.5.0"
+    "release-it": "^15.5.0",
+    "typescript": "^4.9.4"
   },
   "volta": {
-    "node": "14.19.2"
+    "node": "16.19.0"
   },
   "packageManager": "pnpm@7.14.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "author": "Chris Hewell Garrett",
   "scripts": {
-    "prepublishOnly": "cd addon && pnpm run build",
+    "prepare": "cd addon && pnpm run build",
     "release": "release-it",
     "test": "cd test-app && pnpm run test:ember"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,12 @@ importers:
       '@release-it-plugins/lerna-changelog': ^5.0.0
       '@release-it-plugins/workspaces': ^3.2.0
       release-it: ^15.5.0
+      typescript: ^4.9.4
     devDependencies:
       '@release-it-plugins/lerna-changelog': 5.0.0_release-it@15.5.0
       '@release-it-plugins/workspaces': 3.2.0_release-it@15.5.0
       release-it: 15.5.0
+      typescript: 4.9.4
 
   addon:
     specifiers:
@@ -38,9 +40,9 @@ importers:
       rollup: ^2.74.1
       rollup-plugin-copy: ^3.4.0
       rollup-plugin-delete: ^2.0.0
-      rollup-plugin-ts: ^3.0.2
+      rollup-plugin-ts: ^3.2.0
       tslib: ^2.4.0
-      typescript: ^4.8.4
+      typescript: 4.9.4
     dependencies:
       '@embroider/addon-shim': 1.8.3
       ember-tracked-storage-polyfill: 1.0.0
@@ -54,8 +56,8 @@ importers:
       '@rollup/plugin-babel': 5.3.1_vyv4jbhmcriklval33ak5sngky
       '@tsconfig/ember': 1.0.1
       '@types/ember__debug': 4.0.2_@babel+core@7.19.6
-      '@typescript-eslint/eslint-plugin': 5.42.0_6xw5wg2354iw4zujk2f3vyfrzu
-      '@typescript-eslint/parser': 5.42.0_wyqvi574yv7oiwfeinomdzmc3m
+      '@typescript-eslint/eslint-plugin': 5.42.0_aztydxbwb5dw26jymrshygayce
+      '@typescript-eslint/parser': 5.42.0_v5bglvupnukcksncywgdzapdrq
       eslint: 8.26.0
       eslint-config-prettier: 8.5.0_eslint@8.26.0
       eslint-plugin-ember: 10.6.1_eslint@8.26.0
@@ -67,9 +69,9 @@ importers:
       rollup: 2.79.1
       rollup-plugin-copy: 3.4.0
       rollup-plugin-delete: 2.0.0
-      rollup-plugin-ts: 3.0.2_f4gh6f7w35rko2ehcg6ii3ezbm
+      rollup-plugin-ts: 3.2.0_3zh5apyww2onomiomncn53r5mu
       tslib: 2.4.1
-      typescript: 4.8.4
+      typescript: 4.9.4
 
   test-app:
     specifiers:
@@ -119,7 +121,7 @@ importers:
       qunit: ^2.19.1
       qunit-dom: ^2.0.0
       tracked-built-ins: workspace:*
-      typescript: ^4.8.4
+      typescript: 4.9.4
       webpack: ^5.74.0
     devDependencies:
       '@babel/core': 7.20.12
@@ -134,8 +136,8 @@ importers:
       '@types/ember__debug': 4.0.2_@babel+core@7.20.12
       '@types/qunit': 2.19.3
       '@types/rsvp': 4.0.4
-      '@typescript-eslint/eslint-plugin': 5.42.0_6xw5wg2354iw4zujk2f3vyfrzu
-      '@typescript-eslint/parser': 5.42.0_wyqvi574yv7oiwfeinomdzmc3m
+      '@typescript-eslint/eslint-plugin': 5.42.0_aztydxbwb5dw26jymrshygayce
+      '@typescript-eslint/parser': 5.42.0_v5bglvupnukcksncywgdzapdrq
       broccoli-asset-rev: 3.0.0
       ember-auto-import: 2.4.3_webpack@5.74.0
       ember-cli: 4.3.0
@@ -168,7 +170,7 @@ importers:
       qunit: 2.19.3
       qunit-dom: 2.0.0
       tracked-built-ins: link:../addon
-      typescript: 4.8.4
+      typescript: 4.9.4
       webpack: 5.74.0
 
 packages:
@@ -2084,8 +2086,8 @@ packages:
       upath: 2.0.1
     dev: true
 
-  /@mdn/browser-compat-data/4.2.1:
-    resolution: {integrity: sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA==}
+  /@mdn/browser-compat-data/5.2.32:
+    resolution: {integrity: sha512-EA8skQ+SM6VQNrToJjVEbooQ+B+eytVmJstaCI8UlB8IXvW5i/RfO3mZqu8pNUJK8zhKCIAX7PIdPE4k+rhyzw==}
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:
@@ -2335,6 +2337,21 @@ packages:
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    dev: true
+
+  /@rollup/pluginutils/5.0.2_rollup@2.79.1:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 2.79.1
     dev: true
 
   /@simple-dom/interface/1.4.0:
@@ -2940,7 +2957,7 @@ packages:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.42.0_6xw5wg2354iw4zujk2f3vyfrzu:
+  /@typescript-eslint/eslint-plugin/5.42.0_aztydxbwb5dw26jymrshygayce:
     resolution: {integrity: sha512-5TJh2AgL6+wpL8H/GTSjNb4WrjKoR2rqvFxR/DDTqYNk6uXn8BJMEcncLSpMbf/XV1aS0jAjYwn98uvVCiAywQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2951,23 +2968,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.42.0_wyqvi574yv7oiwfeinomdzmc3m
+      '@typescript-eslint/parser': 5.42.0_v5bglvupnukcksncywgdzapdrq
       '@typescript-eslint/scope-manager': 5.42.0
-      '@typescript-eslint/type-utils': 5.42.0_wyqvi574yv7oiwfeinomdzmc3m
-      '@typescript-eslint/utils': 5.42.0_wyqvi574yv7oiwfeinomdzmc3m
+      '@typescript-eslint/type-utils': 5.42.0_v5bglvupnukcksncywgdzapdrq
+      '@typescript-eslint/utils': 5.42.0_v5bglvupnukcksncywgdzapdrq
       debug: 4.3.4
       eslint: 8.26.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.42.0_wyqvi574yv7oiwfeinomdzmc3m:
+  /@typescript-eslint/parser/5.42.0_v5bglvupnukcksncywgdzapdrq:
     resolution: {integrity: sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2979,10 +2996,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.42.0
       '@typescript-eslint/types': 5.42.0
-      '@typescript-eslint/typescript-estree': 5.42.0_typescript@4.8.4
+      '@typescript-eslint/typescript-estree': 5.42.0_typescript@4.9.4
       debug: 4.3.4
       eslint: 8.26.0
-      typescript: 4.8.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2995,7 +3012,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.42.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.42.0_wyqvi574yv7oiwfeinomdzmc3m:
+  /@typescript-eslint/type-utils/5.42.0_v5bglvupnukcksncywgdzapdrq:
     resolution: {integrity: sha512-HW14TXC45dFVZxnVW8rnUGnvYyRC0E/vxXShFCthcC9VhVTmjqOmtqj6H5rm9Zxv+ORxKA/1aLGD7vmlLsdlOg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3005,12 +3022,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.42.0_typescript@4.8.4
-      '@typescript-eslint/utils': 5.42.0_wyqvi574yv7oiwfeinomdzmc3m
+      '@typescript-eslint/typescript-estree': 5.42.0_typescript@4.9.4
+      '@typescript-eslint/utils': 5.42.0_v5bglvupnukcksncywgdzapdrq
       debug: 4.3.4
       eslint: 8.26.0
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3020,7 +3037,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.42.0_typescript@4.8.4:
+  /@typescript-eslint/typescript-estree/5.42.0_typescript@4.9.4:
     resolution: {integrity: sha512-2O3vSq794x3kZGtV7i4SCWZWCwjEtkWfVqX4m5fbUBomOsEOyd6OAD1qU2lbvV5S8tgy/luJnOYluNyYVeOTTg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3035,13 +3052,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.4
-      typescript: 4.8.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.42.0_wyqvi574yv7oiwfeinomdzmc3m:
+  /@typescript-eslint/utils/5.42.0_v5bglvupnukcksncywgdzapdrq:
     resolution: {integrity: sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3051,7 +3068,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.42.0
       '@typescript-eslint/types': 5.42.0
-      '@typescript-eslint/typescript-estree': 5.42.0_typescript@4.8.4
+      '@typescript-eslint/typescript-estree': 5.42.0_typescript@4.9.4
       eslint: 8.26.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.26.0
@@ -4423,32 +4440,20 @@ packages:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
     dev: true
 
-  /browserslist-generator/1.0.66:
-    resolution: {integrity: sha512-aFDax4Qzh29DdyhHQBD2Yu2L5OvaDnvYFMbmpLrLwwaNK4H6dHEhC/Nxv93/+mfAA+a/t94ln0P2JZvHO6LZDA==}
-    engines: {node: '>=8.0.0'}
+  /browserslist-generator/2.0.2:
+    resolution: {integrity: sha512-jQ0EIPx4P0k4/AF3cYuEQ49OByCAOJU5jc0ZLiw9WZlLdAkm3rxJIca+AIltAiKe4hcUMqtozsL3s+FYSs3ojQ==}
+    engines: {node: '>=16.15.1', npm: '>=7.0.0', pnpm: '>=3.2.0', yarn: '>=1.13'}
     dependencies:
-      '@mdn/browser-compat-data': 4.2.1
+      '@mdn/browser-compat-data': 5.2.32
       '@types/object-path': 0.11.1
       '@types/semver': 7.3.13
       '@types/ua-parser-js': 0.7.36
-      browserslist: 4.20.2
-      caniuse-lite: 1.0.30001429
-      isbot: 3.4.5
+      browserslist: 4.21.4
+      caniuse-lite: 1.0.30001449
+      isbot: 3.6.5
       object-path: 0.11.8
       semver: 7.3.8
-      ua-parser-js: 1.0.32
-    dev: true
-
-  /browserslist/4.20.2:
-    resolution: {integrity: sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001429
-      electron-to-chromium: 1.4.284
-      escalade: 3.1.1
-      node-releases: 2.0.6
-      picocolors: 1.0.0
+      ua-parser-js: 1.0.33
     dev: true
 
   /browserslist/4.21.4:
@@ -4605,6 +4610,10 @@ packages:
 
   /caniuse-lite/1.0.30001429:
     resolution: {integrity: sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg==}
+
+  /caniuse-lite/1.0.30001449:
+    resolution: {integrity: sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==}
+    dev: true
 
   /capture-exit/2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -4913,14 +4922,14 @@ packages:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
     dev: true
 
-  /compatfactory/1.0.1_typescript@4.8.4:
-    resolution: {integrity: sha512-hR9u0HSZTKDNNchPtMHg6myeNx0XO+av7UZIJPsi4rPALJBHi/W5Mbwi19hC/xm6y3JkYpxVYjTqnSGsU5X/iw==}
+  /compatfactory/2.0.9_typescript@4.9.4:
+    resolution: {integrity: sha512-fvO+AWcmbO7P1S+A3mwm3IGr74eHMeq5ZLhNhyNQc9mVDNHT4oe0Gg0ksdIFFNXLK7k7Z/TYcLAUSQdRgh1bsA==}
     engines: {node: '>=14.9.0'}
     peerDependencies:
       typescript: '>=3.x || >= 4.x'
     dependencies:
-      helpertypes: 0.0.18
-      typescript: 4.8.4
+      helpertypes: 0.0.19
+      typescript: 4.9.4
     dev: true
 
   /component-emitter/1.3.0:
@@ -8106,8 +8115,8 @@ packages:
     dependencies:
       rsvp: 3.2.1
 
-  /helpertypes/0.0.18:
-    resolution: {integrity: sha512-XRhfbSEmR+poXUC5/8AbmYNJb2riOT6qPzjGJZr0S9YedHiaY+/tzPYzWMUclYMEdCYo/1l8PDYrQFCj02v97w==}
+  /helpertypes/0.0.19:
+    resolution: {integrity: sha512-J00e55zffgi3yVnUp0UdbMztNkr2PnizEkOe9URNohnrNhW5X0QpegkuLpOmFQInpi93Nb8MCjQRHAiCDF42NQ==}
     engines: {node: '>=10.0.0'}
     dev: true
 
@@ -8787,8 +8796,8 @@ packages:
     engines: {node: '>= 8.0.0'}
     dev: true
 
-  /isbot/3.4.5:
-    resolution: {integrity: sha512-+KD6q1BBtw0iK9aGBGSfxJ31/ZgizKRjhm8ebgJUBMx0aeeQuIJ1I72beCoIrltIZGrSm4vmrxRxrG5n1aUTtw==}
+  /isbot/3.6.5:
+    resolution: {integrity: sha512-BchONELXt6yMad++BwGpa0oQxo/uD0keL7N15cYVf0A1oMIoNQ79OqeYdPMFWDrNhCqCbRuw9Y9F3QBjvAxZ5g==}
     engines: {node: '>=12'}
     dev: true
 
@@ -9402,6 +9411,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: true
+
+  /magic-string/0.27.0:
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
   /make-dir/3.1.0:
@@ -11481,8 +11497,8 @@ packages:
       del: 5.1.0
     dev: true
 
-  /rollup-plugin-ts/3.0.2_f4gh6f7w35rko2ehcg6ii3ezbm:
-    resolution: {integrity: sha512-67qi2QTHewhLyKDG6fX3jpohWpmUPPIT/xJ7rsYK46X6MqmoWy64Ti0y8ygPfLv8mXDCdRZUofM3mTxDfCswRA==}
+  /rollup-plugin-ts/3.2.0_3zh5apyww2onomiomncn53r5mu:
+    resolution: {integrity: sha512-KkTLVifkUexEiAXS9VtSjDrjKr0TyusmNJpb2ZTAzI9VuPumSu4AktIaVNnwv70iUEitHwZtET7OAM+5n1u1tg==}
     engines: {node: '>=14.9.0', npm: '>=7.0.0', pnpm: '>=3.2.0', yarn: '>=1.13'}
     peerDependencies:
       '@babel/core': '>=6.x || >=7.x'
@@ -11513,18 +11529,18 @@ packages:
       '@babel/core': 7.19.6
       '@babel/preset-typescript': 7.18.6_@babel+core@7.19.6
       '@babel/runtime': 7.20.1
-      '@rollup/pluginutils': 4.2.1
+      '@rollup/pluginutils': 5.0.2_rollup@2.79.1
       '@wessberg/stringutil': 1.0.19
       ansi-colors: 4.1.3
       browserslist: 4.21.4
-      browserslist-generator: 1.0.66
-      compatfactory: 1.0.1_typescript@4.8.4
+      browserslist-generator: 2.0.2
+      compatfactory: 2.0.9_typescript@4.9.4
       crosspath: 2.0.0
-      magic-string: 0.26.7
+      magic-string: 0.27.0
       rollup: 2.79.1
-      ts-clone-node: 1.0.0_typescript@4.8.4
+      ts-clone-node: 2.0.4_typescript@4.9.4
       tslib: 2.4.1
-      typescript: 4.8.4
+      typescript: 4.9.4
     dev: true
 
   /rollup/2.79.1:
@@ -12674,14 +12690,14 @@ packages:
       - supports-color
     dev: true
 
-  /ts-clone-node/1.0.0_typescript@4.8.4:
-    resolution: {integrity: sha512-/cDYbr2HAXxFNeTT41c/xs/2bhLJjqnYheHsmA3AoHSt+n4JA4t0FL9Lk5O8kWnJ6jeB3kPcUoXIFtwERNzv6Q==}
+  /ts-clone-node/2.0.4_typescript@4.9.4:
+    resolution: {integrity: sha512-eG6FAgmQsenhIJOIFhUcO6yyYejBKZIKcI3y21jiQmIOrth5pD6GElyPAyeihbPSyBs3u/9PVNXy+5I7jGy8jA==}
     engines: {node: '>=14.9.0'}
     peerDependencies:
       typescript: ^3.x || ^4.x
     dependencies:
-      compatfactory: 1.0.1_typescript@4.8.4
-      typescript: 4.8.4
+      compatfactory: 2.0.9_typescript@4.9.4
+      typescript: 4.9.4
     dev: true
 
   /tslib/1.14.1:
@@ -12692,14 +12708,14 @@ packages:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
     dev: true
 
-  /tsutils/3.21.0_typescript@4.8.4:
+  /tsutils/3.21.0_typescript@4.9.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.8.4
+      typescript: 4.9.4
     dev: true
 
   /type-check/0.3.2:
@@ -12758,14 +12774,14 @@ packages:
   /typescript-memoize/1.1.1:
     resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
 
-  /typescript/4.8.4:
-    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+  /typescript/4.9.4:
+    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
 
-  /ua-parser-js/1.0.32:
-    resolution: {integrity: sha512-dXVsz3M4j+5tTiovFVyVqssXBu5HM47//YSOeZ9fQkdDKkfzv2v3PP1jmH6FUyPW+yCSn7aBVK1fGGKNhowdDA==}
+  /ua-parser-js/1.0.33:
+    resolution: {integrity: sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ==}
     dev: true
 
   /uc.micro/1.0.6:

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -72,7 +72,7 @@
     "qunit": "^2.19.1",
     "qunit-dom": "^2.0.0",
     "tracked-built-ins": "workspace:*",
-    "typescript": "^4.8.4",
+    "typescript": "4.9.4",
     "webpack": "^5.74.0"
   },
   "engines": {


### PR DESCRIPTION
- Bump to the latest 4.9 patch release of TS itself.
- Update to the latest version of `rollup-plugin-ts`, and update pinned version of Node to v16 in `volta` config.
- Remove now-meaningless `engines` field from `package.json`: we have no build-time output to run in Node.
- Use `prepublishOnly`, not `prepare`, so that we don't needlessly build the package after installation (matching what we do in the rest of the ecosystem).