### PR TITLE
Run `pnpm install` after version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "release-it": {
     "hooks": {
-      "before:init": "cp README.md LICENSE.md addon/"
+      "before:init": "cp README.md LICENSE.md addon/",
+      "after:bump": "pnpm install"
     },
     "plugins": {
       "@release-it-plugins/lerna-changelog": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
       prettier: ^2.6.2
       qunit: ^2.19.1
       qunit-dom: ^2.0.0
-      tracked-built-ins: workspace:*
+      tracked-built-ins: 3.2.0
       typescript: ^4.8.4
       webpack: ^5.74.0
     devDependencies:


### PR DESCRIPTION
@chriskrycho this is the fix for the error ` ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with test-app/package.json` seen in https://github.com/tracked-tools/tracked-built-ins/actions/runs/4046979099/jobs/6960441946 after the release.

was doing the same in https://github.com/ember-animation/ember-animated/blob/master/package.json#L37 and it works