### PR TITLE
Backport: Introduce flag for length access after push/unshift

### DIFF
--- a/tests/unit/array-test.ts
+++ b/tests/unit/array-test.ts
@@ -387,6 +387,48 @@ module('TrackedArray', function (hooks) {
       }
     );
 
+    reactivityTest(
+      'Can push into a newly created TrackedArray during construction',
+      class extends Component {
+        arr = new TrackedArray<string>();
+
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        constructor(owner: unknown, args: {}) {
+          super(owner, args);
+          this.arr.push('hello');
+        }
+
+        get value() {
+          return this.arr[0];
+        }
+
+        update() {
+          this.arr[0] = 'goodbye';
+        }
+      }
+    );
+
+    reactivityTest(
+      'Can unshift into a newly created TrackedArray during construction',
+      class extends Component {
+        arr = new TrackedArray<string>();
+
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        constructor(owner: unknown, args: {}) {
+          super(owner, args);
+          this.arr.unshift('hello');
+        }
+
+        get value() {
+          return this.arr[0];
+        }
+
+        update() {
+          this.arr[0] = 'goodbye';
+        }
+      }
+    );
+
     eachReactivityTest(
       '{{each}} works with new items',
       class extends Component {


### PR DESCRIPTION
Backport of #397 for a 3.1.1 release. There are some (known) bugs with lazy engines and ember-auto-import which make pulling in a v2 addon difficult in some cases. This should unblock that.