### PR TITLE
Update compatibility section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ Compatibility
 ------------------------------------------------------------------------------
 
 * Ember.js v3.24 (LTS) or above
-* Ember CLI v3.23 or above
-* Node.js v14 or above
+* Embroider or ember-auto-import v2
 
 ### TypeScript
 


### PR DESCRIPTION
As this is now v2 addon, there is no Ember CLI or Node.js requirement, instead it's Embroider/ember-auto-import