### PR TITLE
Ensure `storages` are cleaned up when elements are removed

### DIFF
--- a/addon/src/-private/array.ts
+++ b/addon/src/-private/array.ts
@@ -161,11 +161,8 @@ class TrackedArray<T = unknown> {
 
         let index = convertToInt(prop);
 
-        if (index !== null) {
-          self.#dirtyStorageFor(index);
-          setValue(self.#collection, null);
-        } else if (prop === 'length') {
-          setValue(self.#collection, null);
+        if (index !== null || prop === 'length') {
+          self.#dirtyCollection();
         }
 
         return true;
@@ -198,6 +195,11 @@ class TrackedArray<T = unknown> {
     if (storage) {
       setValue(storage, null);
     }
+  }
+
+  #dirtyCollection() {
+    setValue(this.#collection, null);
+    this.#storages.clear();
   }
 }
 

--- a/addon/src/-private/map.ts
+++ b/addon/src/-private/map.ts
@@ -116,14 +116,16 @@ export class TrackedMap<K = unknown, V = unknown> implements Map<K, V> {
     this.dirtyStorageFor(key);
     setValue(this.collection, null);
 
+    this.storages.delete(key);
     return this.vals.delete(key);
   }
 
   // **** ALL SETTERS ****
   clear(): void {
     this.storages.forEach((s) => setValue(s, null));
-    setValue(this.collection, null);
+    this.storages.clear();
 
+    setValue(this.collection, null);
     this.vals.clear();
   }
 }
@@ -192,6 +194,7 @@ export class TrackedWeakMap<K extends object = object, V = unknown>
   delete(key: K): boolean {
     this.dirtyStorageFor(key);
 
+    this.storages.delete(key);
     return this.vals.delete(key);
   }
 

--- a/addon/src/-private/object.js
+++ b/addon/src/-private/object.js
@@ -54,6 +54,7 @@ export default class TrackedObject {
         if (prop in target) {
           delete target[prop];
           self.#dirtyStorageFor(prop);
+          self.#storages.delete(prop);
           self.#dirtyCollection();
         }
 

--- a/addon/src/-private/set.ts
+++ b/addon/src/-private/set.ts
@@ -101,6 +101,7 @@ export class TrackedSet<T = unknown> implements Set<T> {
     this.dirtyStorageFor(value);
     setValue(this.collection, null);
 
+    this.storages.delete(value);
     return this.vals.delete(value);
   }
 
@@ -109,6 +110,7 @@ export class TrackedSet<T = unknown> implements Set<T> {
     this.storages.forEach((s) => setValue(s, null));
     setValue(this.collection, null);
 
+    this.storages.clear();
     this.vals.clear();
   }
 }
@@ -163,6 +165,7 @@ export class TrackedWeakSet<T extends object = object> implements WeakSet<T> {
   delete(value: T): boolean {
     this.dirtyStorageFor(value);
 
+    this.storages.delete(value);
     return this.vals.delete(value);
   }
 


### PR DESCRIPTION
All `Tracked*` collections have an internal map of 'storages'. These were not being cleaned up when elements were removed from the collection, or when the collection was cleared. That meant that every object which was ever in the collection continues to be referenced, and will never be garbage collected. Depending on the use-case, this can lead to an unbound memory leak.

This commit ensures that the storages are deleted/cleared appropriately.

I can't think of a sensible way to test this, because the 'storages' map is private (in some cases via typescript `private` keyword, and in other cases via a native private class field).