### PR TITLE
Fix TS Matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,5 +152,8 @@ jobs:
         working-directory: test-app
 
       - name: Type check
-        run: pnpm lint:types
+        run: |
+          pnpm tsc --version
+          pnpm lint:types
+
         working-directory: test-app


### PR DESCRIPTION
our TS matrix was only testing if it could build the addon. which none of our consumers will do.


This change changes the TS version on the test-app, which is a much more reliable indicator if TS will work in a consuming project.